### PR TITLE
Fix ElevenLabs outbound call payload nesting

### DIFF
--- a/fix_post_call.md
+++ b/fix_post_call.md
@@ -1,0 +1,134 @@
+Yep, that screenshot tells the story: your Slack formatter is running, but it’s pulling from the wrong part of the post-call payload, so every field comes back undefined → you turn it into N/A.
+
+Also quick side note: those RTF files you uploaded earlier with the payload samples have expired on my side, so if you ever want me to re-open them you’d need to re-upload. Not needed for this fix though.
+
+⸻
+
+Where your data actually lives
+
+From ElevenLabs’ docs, the post_call_transcription webhook looks like this:  ￼
+
+{
+  "type": "post_call_transcription",
+  "data": {
+    "conversation_id": "abc",
+    "status": "done",
+    "metadata": {
+      "call_duration_secs": 22
+    },
+    "conversation_initiation_client_data": {
+      "dynamic_variables": {
+        "first_name": "Rudolph",
+        "last_name": "RedNose",
+        "lead_phone": "+1817…",
+        "customer_address": "199 Co Rd 4840",
+        "wix_submission_id": "…",
+        "wix_contact_id": "…",
+        "preferred_callback_time": "now",
+        "consent_to_call_now": true,
+        "request_type": "Residential Garage Doors Request",
+        ...
+      }
+    }
+  }
+}
+
+So for post-call you need to read from:
+	•	Dynamic vars:
+req.body.data.conversation_initiation_client_data.dynamic_variables
+	•	Conversation ID:
+req.body.data.conversation_id
+	•	Status:
+req.body.data.status
+	•	Duration:
+req.body.data.metadata.call_duration_secs
+
+Right now you’re almost certainly doing something like:
+
+const { lead_full_name, lead_phone } = payload.client_data || {};
+
+→ client_data is undefined in post-call webhooks, so everything falls back to N/A.
+status shows “completed” because you’re either hard-coding it or reading data.status correctly while everything else is wrong.
+
+⸻
+
+Fix your post-call handler
+
+Update your post-call endpoint roughly like this:
+
+app.post('/api/elevenlabs/post-call', async (req, res) => {
+  try {
+    const payload = req.body;
+
+    // 1) Pull the dynamic variables from the correct place
+    const dyn =
+      payload?.data?.conversation_initiation_client_data?.dynamic_variables || {};
+
+    const {
+      lead_full_name,
+      first_name,
+      last_name,
+      lead_phone,
+      customer_address,
+      preferred_callback_time,
+      consent_to_call_now,
+      wix_submission_id,
+      wix_contact_id,
+      request_type,
+    } = dyn;
+
+    // 2) Other call metadata
+    const conversation_id = payload?.data?.conversation_id;
+    const status = payload?.data?.status;
+    const duration_secs = payload?.data?.metadata?.call_duration_secs;
+
+    const name =
+      lead_full_name || [first_name, last_name].filter(Boolean).join(' ') || 'N/A';
+
+    const text = `
+:telephone_receiver: *New CMAC Call Completed*
+
+*Lead Information:*
+• Name: ${name || 'N/A'}
+• Phone: ${lead_phone || 'N/A'}
+• Address: ${customer_address || 'N/A'}
+
+*Call Details:*
+• Conversation ID: ${conversation_id || 'N/A'}
+• Status: ${status || 'N/A'}
+• Duration: ${duration_secs != null ? duration_secs + 's' : 'N/A'}
+• Request Type: ${request_type || 'N/A'}
+
+*Follow-up:*
+• Preferred Callback Time: ${preferred_callback_time || 'N/A'}
+• Consent to Call Now: ${consent_to_call_now ? 'Yes' : 'No'}
+
+*Tracking:*
+• WIX Submission ID: ${wix_submission_id || 'N/A'}
+• WIX Contact ID: ${wix_contact_id || 'N/A'}
+`.trim();
+
+    await fetch(process.env.SLACK_WEBHOOK_URL, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ text }),
+    });
+
+    res.sendStatus(200);
+  } catch (err) {
+    console.error('Post-call webhook error:', err);
+    res.sendStatus(500);
+  }
+});
+
+One extra sanity check
+
+Add a log once while testing:
+
+console.log('ELEVEN POST-CALL PAYLOAD:', JSON.stringify(req.body, null, 2));
+
+Trigger a call, look at your console, and confirm the data really is under:
+
+data.conversation_initiation_client_data.dynamic_variables
+
+Once you change the path, your Slack message should fill in with the real name, phone, address, WIX IDs, etc. instead of N/A.

--- a/lib/services/outbound-call.ts
+++ b/lib/services/outbound-call.ts
@@ -78,39 +78,45 @@ export class OutboundCallService {
         };
       }
 
+      const firstName = (leadData.first_name || '').trim();
+      const lastName = (leadData.last_name || '').trim();
+      const dynamicVariables = {
+        // Required variables for first message template
+        honorific: firstName ? 'Mr.' : '', // Only use honorific if we have a name
+        request_type: (leadData.request_type || 'roofing inquiry').trim(),
+        source_site: (leadData.source_site || 'our website').trim(),
+        agent_name: 'Penny',
+        last_name: lastName,
+        last_name_suffix: (leadData.last_name_suffix || '').trim(),
+
+        // Lead information
+        lead_full_name: (leadData.lead_full_name || `${firstName} ${lastName}`).trim(),
+        first_name: firstName,
+        lead_phone: leadData.lead_phone || '',
+        address_line1: leadData.address_line1 || '',
+        city: leadData.city || '',
+        state: leadData.state || '',
+        zip: leadData.zip || '',
+        notes: leadData.notes || '',
+        location: leadData.location || '',
+
+        // System tracking
+        wix_submission_id: leadData.wix_submission_id || '',
+        wix_contact_id: leadData.wix_contact_id || '',
+
+        // Default values for agent workflow
+        status: leadData.status || 'new_lead',
+        preferred_callback_time: leadData.preferred_callback_time || 'now',
+        consent_to_call_now: leadData.consent_to_call_now ?? true
+      };
+
       const callPayload = {
         agent_id: this.agentId,
         agent_phone_number_id: phoneNumberId,
         to_number: leadData.lead_phone,
-        // Provide all required dynamic variables for the ElevenLabs agent
         conversation_initiation_client_data: {
-          // Required variables for first message template
-          honorific: leadData.first_name ? 'Mr.' : '', // Only use honorific if we have a name
-          request_type: leadData.request_type || 'roofing inquiry',
-          source_site: 'our website',
-          agent_name: 'Penny',
-          last_name: leadData.last_name ? ` ${leadData.last_name}` : '',
-          last_name_suffix: leadData.last_name_suffix || '',
-
-          // Lead information
-          lead_full_name: leadData.lead_full_name || '',
-          first_name: leadData.first_name || '',
-          lead_phone: leadData.lead_phone || '',
-          address_line1: leadData.address_line1 || '',
-          city: leadData.city || '',
-          state: leadData.state || '',
-          zip: leadData.zip || '',
-          notes: leadData.notes || '',
-          location: leadData.location || '',
-
-          // System tracking
-          wix_submission_id: leadData.wix_submission_id || '',
-          wix_contact_id: leadData.wix_contact_id || '',
-
-          // Default values for agent workflow
-          status: 'new_lead',
-          preferred_callback_time: 'now',
-          consent_to_call_now: true
+          type: 'conversation_initiation_client_data',
+          dynamic_variables: dynamicVariables
         }
       };
 
@@ -123,7 +129,8 @@ export class OutboundCallService {
         phoneNumberId: phoneNumberId,
         targetPhone: leadData.lead_phone
       });
-      console.log('📋 Dynamic variables being sent:', JSON.stringify(callPayload.conversation_initiation_client_data, null, 2));
+      console.log('📋 Dynamic variables being sent:', JSON.stringify(dynamicVariables, null, 2));
+      console.log('📦 ElevenLabs payload body:', JSON.stringify(callPayload, null, 2));
 
       const response = await fetch(apiUrl, {
         method: 'POST',

--- a/lib/services/outbound-call.ts
+++ b/lib/services/outbound-call.ts
@@ -80,6 +80,7 @@ export class OutboundCallService {
 
       const firstName = (leadData.first_name || '').trim();
       const lastName = (leadData.last_name || '').trim();
+      
       const dynamicVariables = {
         // Required variables for first message template
         honorific: firstName ? 'Mr.' : '', // Only use honorific if we have a name
@@ -93,6 +94,7 @@ export class OutboundCallService {
         lead_full_name: (leadData.lead_full_name || `${firstName} ${lastName}`).trim(),
         first_name: firstName,
         lead_phone: leadData.lead_phone || '',
+        customer_address: (leadData.address_line1 || '').trim(), // Map to address_line1 for ElevenLabs agent
         address_line1: leadData.address_line1 || '',
         city: leadData.city || '',
         state: leadData.state || '',

--- a/lib/store.ts
+++ b/lib/store.ts
@@ -3,6 +3,7 @@ import Redis from 'ioredis';
 export interface LeadData {
   first_name: string;
   last_name: string;
+  last_name_suffix?: string;
   lead_full_name: string;
   lead_phone: string;
   address_line1: string;
@@ -15,6 +16,9 @@ export interface LeadData {
   source_site: string;
   wix_submission_id: string;
   wix_contact_id: string;
+  status?: string;
+  preferred_callback_time?: string;
+  consent_to_call_now?: boolean;
 }
 
 class Store {

--- a/post_call_detail.md
+++ b/post_call_detail.md
@@ -1,0 +1,85 @@
+Yep, that Post-Call Webhook box is exactly where you hook in the “send this to Slack when the call ends” logic.
+
+But: don’t point it directly at Slack’s webhook URL. ElevenLabs will POST its own JSON payload; Slack’s incoming webhook expects a totally different JSON shape. You need a tiny middleman.
+
+Wiring it up
+	1.	Add a post-call endpoint on your server
+
+Something like:
+
+// e.g. /api/elevenlabs/post-call
+app.post('/api/elevenlabs/post-call', async (req, res) => {
+  try {
+    const payload = req.body;
+
+    // pull what you care about
+    const {
+      lead_full_name,
+      first_name,
+      last_name,
+      lead_phone,
+      customer_address,
+      status,
+      preferred_callback_time,
+      consent_to_call_now,
+      conversation_id,
+      // depends on what ElevenLabs sends – transcript, summary, etc.
+    } = payload.client_data || {};
+
+    const text = `
+📞 *New CMAC Call Completed*
+• Name: ${lead_full_name || `${first_name} ${last_name}`}
+• Phone: ${lead_phone}
+• Address: ${customer_address}
+• Status: ${status}
+• Pref time: ${preferred_callback_time}
+• Consent now: ${consent_to_call_now}
+• Conv ID: ${conversation_id}
+    `.trim();
+
+    await fetch(process.env.SLACK_WEBHOOK_URL, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ text }),
+    });
+
+    res.sendStatus(200);
+  } catch (err) {
+    console.error('Post-call webhook error:', err);
+    res.sendStatus(500);
+  }
+});
+
+	2.	Expose it via ngrok
+
+You already have https://cojovi.ngrok.dev/api/elevenlabs/init.
+Do the same for your new route, e.g.:
+
+https://cojovi.ngrok.dev/api/elevenlabs/post-call
+	3.	Configure ElevenLabs
+
+	•	Go to Workspace → Agents Settings (same screen you screenshotted).
+	•	Click Create Webhook under Post-Call Webhook.
+	•	Paste your https://cojovi.ngrok.dev/api/elevenlabs/post-call URL there and save.
+
+	4.	Configure Slack app
+
+	•	Enable Incoming Webhooks for your Slack app.
+	•	Create a webhook for the target channel.
+	•	Put that URL in SLACK_WEBHOOK_URL (env var your server uses).
+
+After that, every time a call ends, ElevenLabs hits your post-call endpoint → your server formats the data → Slack gets a nice “Call completed” message in the channel.
+
+
+Slack Details:
+
+**Note:** Store all Slack credentials in environment variables (`.env` file) - never commit secrets to git.
+
+Required environment variable:
+- `SLACK_WEBHOOK_URL` - Your Slack incoming webhook URL
+
+To get your webhook URL:
+1. Go to your Slack app settings
+2. Enable Incoming Webhooks
+3. Create a webhook for your target channel
+4. Copy the webhook URL and add it to your `.env` file as `SLACK_WEBHOOK_URL`


### PR DESCRIPTION
## Summary
- wrap outbound call dynamic variables inside `conversation_initiation_client_data` with the required `type` and snake_case payload keys
- trim lead details before sending them to ElevenLabs and reuse the normalized data to populate the dynamic variables block
- extend the stored lead data interface so optional call metadata can be forwarded during outbound dialing and improve payload logging

## Testing
- `npm run type-check` *(fails: existing strict TypeScript errors in normalize.ts, outbound-call.ts, phone-import.ts, and store.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68e0158bf3788330bf5efbc926187d9d